### PR TITLE
Add RevPi SOS report plugins [REVPI-1692]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright 2023 KUNBUS GmbH
+#
+cmake_minimum_required(VERSION 3.13)
+
+project(revpi-sos)
+
+include(GNUInstallDirs)
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
+install(PROGRAMS revpi-sos
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES plugins/revpi.py plugins/revpi-eep.py plugins/revpi-codesys.py
+  DESTINATION ${Python3_SITELIB}/sos/report/plugins/
+)
+
+install(FILES revpi-sos.1
+  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+)

--- a/plugins/revpi-codesys.py
+++ b/plugins/revpi-codesys.py
@@ -1,0 +1,37 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright 2020-2023 KUNBUS GmbH
+#
+
+
+from sos.report.plugins import Plugin, DebianPlugin
+
+
+class RevPiCodesys(Plugin, DebianPlugin):
+    """
+    This plugin gathers Revolution Pi CODESYS specific information.
+
+    The output of this plugin is used in the revpi-soss-report archive, which
+    often is requested by the support team.
+    """
+
+    short_desc = "Revolution Pi CODEDSYS information"
+
+    requires_root = True
+    profiles = ("system",)
+    plugin_name = "revpi-codesys"
+
+    packages = ("codesyscontrol",)
+
+    def setup(self):
+        self.add_copy_spec(
+            [
+                "/etc/CODESYSControl.cfg",
+                "/etc/CODESYSControl_User.cfg",
+                "/tmp/codesyscontrol.log",
+            ]
+        )
+
+
+# vim: set et ts=4 sw=4 :

--- a/plugins/revpi-eep.py
+++ b/plugins/revpi-eep.py
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright 2023 KUNBUS GmbH
+#
+
+
+from sos.report.plugins import Plugin, DebianPlugin
+
+
+class RevPiEEP(Plugin, DebianPlugin):
+    """
+    This plugin gathers Revolution Pi specific information from the HAT eeprom.
+
+    The output of this plugin is used in the revpi-sos-report archive, which
+    often is requested by the support team.
+    """
+
+    short_desc = "Revolution Pi EEP information"
+
+    requires_root = False
+    profiles = ("system",)
+    plugin_name = "revpi-eep"
+
+    packages = ("python3-revpi-device-info",)
+
+    def setup(self):
+        self.add_cmd_output(
+            [
+                "revpi-device-info",
+            ]
+        )
+
+
+# vim: set et ts=4 sw=4 :

--- a/plugins/revpi.py
+++ b/plugins/revpi.py
@@ -1,0 +1,65 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright 2020-2023 KUNBUS GmbH
+#
+
+
+from sos.report.plugins import Plugin, DebianPlugin
+
+
+class RevPi(Plugin, DebianPlugin):
+    """
+    This plugin gathers Revolution Pi specific information from the system
+
+    The output of this plugin is used in the revpi-sos-report archive, which
+    often is requested by the support team.
+    """
+
+    short_desc = "Revolution Pi information"
+
+    requires_root = True
+    profiles = ("system",)
+    plugin_name = "revpi"
+
+    def setup(self):
+        self.add_copy_spec(
+            [
+                "/var/log/messages",
+                "/var/log/apache2/error.log",
+                "/var/log/kern.log",
+                "/var/log/daemon.log",
+                "/etc/revpi/config.rsc",
+                "/boot/cmdline.txt",
+                "/boot/config.txt",
+                "/etc/revpi/image-release",
+                "/etc/dhcpcd.conf",
+                "/etc/network/interfaces",
+                "/etc/resolv.conf",
+            ]
+        )
+
+        self.add_cmd_output(
+            [
+                "df -h",
+                "dmesg",
+                "uname -a",
+                "piTest -d",
+                "ps -ax",
+                "ls /dev/ttyUSB*",
+                "ls /dev/ttyRS485",
+                "ls -l /etc/revpi/config.rsc",
+                "vcgencmd measure_temp",
+                "vcgencmd measure_clock arm",
+                "lsusb -v",
+                "free",
+                "apt-cache show pictory",
+                "apt-cache show revpi-webstatus",
+                "apt-cache show raspberrypi-kernel",
+                "netstat -ln",
+                "vcgencmd version",
+            ]
+        )
+
+
+# vim: set et ts=4 sw=4 :

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/revpi-sos
+++ b/revpi-sos
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright 2020-2023 KUNBUS GmbH
+#
+
+ret=1
+force=0
+
+while getopts ":fh" OPTION; do
+	case ${OPTION} in
+	f)
+		force=1
+		;;
+	h)
+		ret=0
+		;&
+	*)
+		echo "Usage: revpi-sos [OPTION...]"
+		echo "  -f	execute without confirmation"
+		echo "  -h	give this help list"
+		exit $ret
+		;;
+	esac
+
+done
+
+if [ "$force" != "1" ]; then
+	read -rp "The report will be generated under folder /tmp in a .tar.xz file, which
+can be extracted with command: tar -Jxvf xxx.tar.xz in linux or 7zip in Windows.
+And then some inspection can be done before it is sent to support@kunbus.com.
+Are you going to continue (N/y)?" -n 1 t_ant
+
+	if [ "$t_ant" != "y" ] && [ "$t_ant" != "Y" ]; then
+		echo
+		exit 0
+	fi
+	echo
+fi
+
+echo "report generating..."
+SOSFILE=$(sudo sos report -o revpi,revpi-eep,revpi-codesys --batch | grep "/tmp/sosreport" | sed -e 's/^[ \t]*//')
+echo
+echo "Your report has been generated and saved in:"
+echo "$SOSFILE"
+echo
+
+if [ "$force" != "1" ]; then
+	read -rp "To make the report have better accessibility, the ownership of the report
+can be changed to the current user.
+Are you going to proceed(N/y)?" -n 1 t_ant
+	if [ "$t_ant" != "y" ] && [ "$t_ant" != "Y" ]; then
+		echo
+		exit 0
+	fi
+	echo
+fi
+
+sudo chown "$USER" "$SOSFILE"
+echo "The ownership of $SOSFILE has been changed to user: $USER"

--- a/revpi-sos.1
+++ b/revpi-sos.1
@@ -1,0 +1,99 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2016-2023 KUNBUS GmbH
+.\"
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH revpi-sos 1 "January 17 2023"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+revpi-sos \- collect the information for RevPi related problems debugging
+.SH SYNOPSIS
+.B revpi-sos
+.RI [ options ]
+.SH DESCRIPTION
+.B revpi-sos
+base on sosreport(1) to collect the needed information for debugging.
+.TP
+The information includes following files:
+.br
+/var/log/messages
+.br
+/var/log/kern.log
+.br
+/var/log/daemon.log
+.br
+/var/log/apache2/error.log
+.br
+/var/www/pictory/projects/_config.rsc
+.br
+/boot/cmdline.txt
+.br
+/boot/config.txt
+.br
+/etc/dhcpcd.conf
+.br
+/etc/resolv.conf
+.br
+/etc/revpi/image-release
+.br
+/etc/network/interfaces
+.TP
+and output of following commands:
+.br
+df -h
+.br
+dmesg
+.br
+uname -a
+.br
+piTest -d
+.br
+ps -ax
+.br
+lsusb -v
+.br
+free
+.br
+apt-cache show pictory
+.br
+apt-cache show revpi-webstatus
+.br
+apt-cache show raspberrypi-kernel
+.br
+netstat -ln
+.br
+ls /dev/ttyUSB*
+.br
+ls /dev/ttyRS485
+.br
+ls -l /etc/revpi/config.rsc
+.br
+vcgencmd version
+.br
+vcgencmd measure_temp
+.br
+vcgencmd measure_clock arm
+.br
+revpi-device-info
+.SH OPTIONS
+.TP
+.B \-f
+Execute without confirmation(generating the report and change the ownership to current user).
+.TP
+.B \-h
+Show the help list.
+.SH SEE ALSO
+For more information on Revolution Pi visit
+.IR https://revolutionpi.com


### PR DESCRIPTION
The RevPi plugins for sos report are useful tools for supporting customers during troubleshooting and often used by our support agents. In the past these plugins were part of the revpi-tools package. In order to strip revpi-tools to a bare minimum (for example for OEM customers), these plugins are moved into a separate package called revpi-sos-report.

Starting with Debian Bullseye the plugin structure of sos report has changed. This is fixed by a rewrite of the old plugins. While doing this the monolithic plugin is broken into three smaler plugins with a specific speciality (eg. CODESYS or HAT EEP).

This is the initial commit of the new repository.