### PR TITLE
feat: Add option to specify output directory and owner of reports.

### DIFF
--- a/revpi-sos
+++ b/revpi-sos
@@ -6,10 +6,11 @@
 #
 
 sos_tmp_dir=/tmp
+sos_owner=$USER
 ret=1
 force=0
 
-while getopts ":fhd:" OPTION; do
+while getopts ":fhd:o:" OPTION; do
 	case ${OPTION} in
 	f)
 		force=1
@@ -17,12 +18,16 @@ while getopts ":fhd:" OPTION; do
 	d)
 		sos_tmp_dir="$OPTARG"
 		;;
+	o)
+		sos_owner="$OPTARG"
+		;;
 	h)
 		ret=0
 		;&
 	*)
 		echo "Usage: revpi-sos [OPTION...]"
 		echo "	-d	DIRECTORY Specify target directory for generated report. If omitted /tmp is used"
+		echo "	-o	USER[:GROUP]	Specify name or uid of user and/or group that will be made owner of generated report."
 		echo "	-f	execute without confirmation"
 		echo "	-h	give this help list"
 		exit $ret
@@ -34,6 +39,7 @@ done
 timestamp=$(date +"%s")
 sos_tmp_dir="$sos_tmp_dir/revpi-sos-$timestamp"
 sudo mkdir -p "$sos_tmp_dir"
+sudo chown -R "$sos_owner" "$sos_tmp_dir"
 
 if [ "$force" != "1" ]; then
 	read -rp "The report will be generated under folder $sos_tmp_dir in a .tar.xz file, which
@@ -59,7 +65,7 @@ printReportFile(){
 
 if [ "$force" != "1" ]; then
 	read -rp "To make the report have better accessibility, the ownership of the report
-can be changed to the current user.
+can be changed to the current user by inheriting ownership from the containing folder.
 Are you going to proceed(N/y)?" -n 1 t_ant
 	if [ "$t_ant" != "y" ] && [ "$t_ant" != "Y" ]; then
 		printReportFile
@@ -68,6 +74,6 @@ Are you going to proceed(N/y)?" -n 1 t_ant
 	echo
 fi
 
-sudo chown "$USER" "$sos_file"
-echo "The ownership of $sos_file has been changed to user: $USER"
+sudo chown -R --reference="$sos_tmp_dir" "$sos_file"*
+echo "The ownership has been inherited from the containing folder $sos_tmp_dir"
 printReportFile

--- a/revpi-sos
+++ b/revpi-sos
@@ -50,22 +50,24 @@ fi
 
 echo "report generating..."
 sudo sos report -o revpi,revpi-eep,revpi-codesys --batch --tmp-dir "$sos_tmp_dir" >/dev/null
-SOSFILE=$(ls "$sos_tmp_dir"/*.tar.xz)
-echo
-echo "Your report has been generated and saved in:"
-echo "$SOSFILE"
-echo
+sos_file=$(ls "$sos_tmp_dir"/*.tar.xz)
+
+printReportFile(){
+		echo "Your sosreport has been generated and saved in:"
+		echo "$sos_file"
+}
 
 if [ "$force" != "1" ]; then
 	read -rp "To make the report have better accessibility, the ownership of the report
 can be changed to the current user.
 Are you going to proceed(N/y)?" -n 1 t_ant
 	if [ "$t_ant" != "y" ] && [ "$t_ant" != "Y" ]; then
-		echo
+		printReportFile
 		exit 0
 	fi
 	echo
 fi
 
-sudo chown "$USER" "$SOSFILE"
-echo "The ownership of $SOSFILE has been changed to user: $USER"
+sudo chown "$USER" "$sos_file"
+echo "The ownership of $sos_file has been changed to user: $USER"
+printReportFile

--- a/revpi-sos
+++ b/revpi-sos
@@ -5,29 +5,38 @@
 # Copyright 2020-2023 KUNBUS GmbH
 #
 
+sos_tmp_dir=/tmp
 ret=1
 force=0
 
-while getopts ":fh" OPTION; do
+while getopts ":fhd:" OPTION; do
 	case ${OPTION} in
 	f)
 		force=1
+		;;
+	d)
+		sos_tmp_dir="$OPTARG"
 		;;
 	h)
 		ret=0
 		;&
 	*)
 		echo "Usage: revpi-sos [OPTION...]"
-		echo "  -f	execute without confirmation"
-		echo "  -h	give this help list"
+		echo "	-d	DIRECTORY Specify target directory for generated report. If omitted /tmp is used"
+		echo "	-f	execute without confirmation"
+		echo "	-h	give this help list"
 		exit $ret
 		;;
 	esac
 
 done
 
+timestamp=$(date +"%s")
+sos_tmp_dir="$sos_tmp_dir/revpi-sos-$timestamp"
+sudo mkdir -p "$sos_tmp_dir"
+
 if [ "$force" != "1" ]; then
-	read -rp "The report will be generated under folder /tmp in a .tar.xz file, which
+	read -rp "The report will be generated under folder $sos_tmp_dir in a .tar.xz file, which
 can be extracted with command: tar -Jxvf xxx.tar.xz in linux or 7zip in Windows.
 And then some inspection can be done before it is sent to support@kunbus.com.
 Are you going to continue (N/y)?" -n 1 t_ant
@@ -40,7 +49,8 @@ Are you going to continue (N/y)?" -n 1 t_ant
 fi
 
 echo "report generating..."
-SOSFILE=$(sudo sos report -o revpi,revpi-eep,revpi-codesys --batch | grep "/tmp/sosreport" | sed -e 's/^[ \t]*//')
+sudo sos report -o revpi,revpi-eep,revpi-codesys --batch --tmp-dir "$sos_tmp_dir" >/dev/null
+SOSFILE=$(ls "$sos_tmp_dir"/*.tar.xz)
 echo
 echo "Your report has been generated and saved in:"
 echo "$SOSFILE"


### PR DESCRIPTION
The directory where the reports will be generated can be specified by providing the path with the parameter -d.

Each SOS report will now be generated in a unique sub-folder with the current timestamp.

This makes it easier to find the correct filenames and makes it possible to fix the ownership of the report files by inheriting from the containing folder.

A specific user and/or group that should be granted ownership of the files can be provided with parameter -o