### PR TITLE
feat: Add option to specify owner of reports

### DIFF
--- a/revpi-sos
+++ b/revpi-sos
@@ -7,11 +7,15 @@
 
 ret=1
 force=0
+SOS_OWNER=$USER
 
-while getopts ":fh" OPTION; do
+while getopts ":fo:h" OPTION; do
 	case ${OPTION} in
 	f)
 		force=1
+		;;
+	o)
+		SOS_OWNER="$OPTARG"
 		;;
 	h)
 		ret=0
@@ -19,6 +23,7 @@ while getopts ":fh" OPTION; do
 	*)
 		echo "Usage: revpi-sos [OPTION...]"
 		echo "  -f	execute without confirmation"
+		echo "  -o	USER[:GROUP]	Specify name or uid of user and/or group that will be made owner of generated report."
 		echo "  -h	give this help list"
 		exit $ret
 		;;
@@ -57,5 +62,5 @@ Are you going to proceed(N/y)?" -n 1 t_ant
 	echo
 fi
 
-sudo chown "$USER" "$SOSFILE"
-echo "The ownership of $SOSFILE has been changed to user: $USER"
+sudo chown "$SOS_OWNER" "$SOSFILE"
+echo "The ownership of $SOSFILE has been changed to user: $SOS_OWNER"


### PR DESCRIPTION
A specific user and/or group that should be granted ownership of the generated report files can now be provided with parameter -o

Superseedes #5 